### PR TITLE
NP-2463 expire Logs when terminating namespace

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -374,6 +374,14 @@
   version = "v0.0.3"
 
 [[projects]]
+  digest = "1:18d316170b65da520a335ae2e11818ed9a481cb57d8fb6c72ee2dc437bb148c4"
+  name = "github.com/nalej/grpc-unified-logging-go"
+  packages = ["."]
+  pruneopts = ""
+  revision = "206ef6835662f9ab80271758948b247756d9284b"
+  version = "v0.0.11"
+
+[[projects]]
   digest = "1:3c48d4db5e7f6c3cda75e4fc1f9b061eb121ec26587bec82059eba37bac619be"
   name = "github.com/nalej/grpc-user-go"
   packages = ["."]
@@ -1038,6 +1046,7 @@
     "github.com/nalej/grpc-installer-go",
     "github.com/nalej/grpc-login-api-go",
     "github.com/nalej/grpc-network-go",
+    "github.com/nalej/grpc-unified-logging-go",
     "github.com/nalej/grpc-utils/pkg/conversions",
     "github.com/nalej/grpc-zt-nalej-go",
     "github.com/onsi/ginkgo",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -80,6 +80,10 @@
     version="=v0.0.24"
 
 [[constraint]]
+    name = "github.com/nalej/grpc-unified-logging-go"
+    version="=v0.0.11"
+
+[[constraint]]
     name = "github.com/nalej/grpc-network-go"
     version="=v0.0.45"
 

--- a/cmd/deployment-manager/cmd/run.go
+++ b/cmd/deployment-manager/cmd/run.go
@@ -113,9 +113,8 @@ func Run() {
 		CACertPath:               viper.GetString("caCertPath"),
 		ClientCertPath:           viper.GetString("clientCertPath"),
 		SkipServerCertValidation: viper.GetBool("skipServerCertValidation"),
-		NetworkType: 		  netType,
-		UnifiedLoggingAddress: viper.GetString("unifiedLoggingAddress"),
-
+		NetworkType:              netType,
+		UnifiedLoggingAddress:    viper.GetString("unifiedLoggingAddress"),
 	}
 
 	log.Info().Msg("launching deployment manager...")

--- a/cmd/deployment-manager/cmd/run.go
+++ b/cmd/deployment-manager/cmd/run.go
@@ -73,6 +73,8 @@ func init() {
 
 	runCmd.Flags().String("networkType", "zt", "Define the underlying networking type for the user apps.")
 
+	runCmd.Flags().String("unifiedLoggingAddress", "localhost:8322", "Unified Logging Slave ∫Address")
+
 	viper.BindPFlags(runCmd.Flags())
 }
 
@@ -112,6 +114,7 @@ func Run() {
 		ClientCertPath:           viper.GetString("clientCertPath"),
 		SkipServerCertValidation: viper.GetBool("skipServerCertValidation"),
 		NetworkType: 		  netType,
+		UnifiedLoggingAddress: viper.GetString("unifiedLoggingAddress"),
 
 	}
 

--- a/cmd/deployment-manager/cmd/run.go
+++ b/cmd/deployment-manager/cmd/run.go
@@ -73,7 +73,7 @@ func init() {
 
 	runCmd.Flags().String("networkType", "zt", "Define the underlying networking type for the user apps.")
 
-	runCmd.Flags().String("unifiedLoggingAddress", "localhost:8322", "Unified Logging Slave ∫Address")
+	runCmd.Flags().String("unifiedLoggingAddress", "localhost:8322", "Unified Logging Slave Address")
 
 	viper.BindPFlags(runCmd.Flags())
 }

--- a/components/deployment-manager/appcluster/deployment-manager.deployment.yaml
+++ b/components/deployment-manager/appcluster/deployment-manager.deployment.yaml
@@ -48,6 +48,7 @@ spec:
         - "--caCertPath=/nalej/ca-certificate/ca.crt"
         - "--clientCertPath=/nalej/tls-client-certificate/"
         - "--skipServerCertValidation=false"
+        - "--unifiedLoggingAddress=unified-logging-slave._NPH_NAMESPACE:8322"
         env:
         - name: MANAGEMENT_HOST
           valueFrom:

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -122,7 +122,6 @@ func GetServiceFQDN(serviceName string, organizationId string, appInstanceId str
 //  The corresponding pointer.
 func BoolPtr(b bool) *bool { return &b }
 
-
 // Helping function for pointer conversion.
 func Int32Ptr(i int32) *int32 { return &i }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -33,7 +33,7 @@ type NetworkType string
 
 const (
 	NetworkTypeError = ""
-	NetworkTypeZt = "zt"
+	NetworkTypeZt    = "zt"
 	NetworkTypeIstio = "istio"
 )
 
@@ -130,7 +130,6 @@ func (conf *Config) Validate() derrors.Error {
 	if conf.MetricsPort <= 0 {
 		return derrors.NewInvalidArgumentError("metricsPort must be valid")
 	}
-
 
 	if conf.ClusterAPIHostname == "" || conf.ClusterAPIPort <= 0 {
 		return derrors.NewInvalidArgumentError("clusterAPIHostname and clusterAPIPort must me set")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -101,6 +101,8 @@ type Config struct {
 	SkipServerCertValidation bool
 	// Network type
 	NetworkType NetworkType
+	// unifiedLoggingAddress
+	UnifiedLoggingAddress string
 }
 
 func (conf *Config) envOrElse(envName string, paramValue string) string {
@@ -161,6 +163,10 @@ func (conf *Config) Validate() derrors.Error {
 	if conf.TargetPlatformName == "" {
 		return derrors.NewInvalidArgumentError("targetPlatform must be set")
 	}
+
+	if conf.UnifiedLoggingAddress == "" {
+		return derrors.NewInvalidArgumentError("UnifiedLoggingAddress must be set")
+	}
 	conf.TargetPlatform = grpc_installer_go.Platform(grpc_installer_go.Platform_value[conf.TargetPlatformName])
 
 	return nil
@@ -183,6 +189,7 @@ func (conf *Config) Print() {
 	log.Info().Str("type", conf.TargetPlatform.String()).Msg("Target platform")
 	log.Info().Uint32("port", conf.ZTSidecarPort).Msg("ZT sidecar config")
 	log.Info().Interface("networkType", conf.NetworkType).Msg("Network type")
+	log.Info().Str("unifiedLoggingAddress", conf.UnifiedLoggingAddress).Msg("Unified Logging Slave Address")
 
 }
 

--- a/pkg/decorators/network/istio/istio_decorator.go
+++ b/pkg/decorators/network/istio/istio_decorator.go
@@ -92,11 +92,11 @@ func (id *IstioDecorator) Build(aux executor.Deployable, args ...interface{}) de
 
 func (id *IstioDecorator) Deploy(aux executor.Deployable, args ...interface{}) derrors.Error {
 
-   switch target := aux.(type) {
-   case *kubernetes.DeployableServices:
-	   return id.decorateServices(target)
-   }
-   return nil
+	switch target := aux.(type) {
+	case *kubernetes.DeployableServices:
+		return id.decorateServices(target)
+	}
+	return nil
 }
 
 // Remove any unnecessary entries when a deployable element is removed.
@@ -129,17 +129,16 @@ func (id *IstioDecorator) decorateServices(target *kubernetes.DeployableServices
 			continue
 		}
 
-
 		// Create a service for this rule
 		newServ := apiv1.Service{
 			ObjectMeta: metaV1.ObjectMeta{
 				Name:      common.FormatName(publicRule.ServiceName),
 				Namespace: target.Data.Namespace,
-				Labels: map[string]string {
-					utils.NALEJ_ANNOTATION_ORGANIZATION_ID : target.Data.OrganizationId,
-					utils.NALEJ_ANNOTATION_APP_DESCRIPTOR : target.Data.AppDescriptorId,
-					utils.NALEJ_ANNOTATION_APP_INSTANCE_ID : target.Data.AppInstanceId,
-					utils.NALEJ_ANNOTATION_IS_PROXY : "false",
+				Labels: map[string]string{
+					utils.NALEJ_ANNOTATION_ORGANIZATION_ID: target.Data.OrganizationId,
+					utils.NALEJ_ANNOTATION_APP_DESCRIPTOR:  target.Data.AppDescriptorId,
+					utils.NALEJ_ANNOTATION_APP_INSTANCE_ID: target.Data.AppInstanceId,
+					utils.NALEJ_ANNOTATION_IS_PROXY:        "false",
 				},
 			},
 			Spec: apiv1.ServiceSpec{
@@ -155,7 +154,7 @@ func (id *IstioDecorator) decorateServices(target *kubernetes.DeployableServices
 				Selector: map[string]string{
 					utils.NALEJ_ANNOTATION_APP_INSTANCE_ID: target.Data.AppInstanceId,
 					utils.NALEJ_ANNOTATION_ORGANIZATION_ID: target.Data.OrganizationId,
-					utils.NALEJ_ANNOTATION_SERVICE_NAME: common.FormatName(publicRule.ServiceName),
+					utils.NALEJ_ANNOTATION_SERVICE_NAME:    common.FormatName(publicRule.ServiceName),
 				},
 			},
 		}
@@ -180,20 +179,20 @@ func (id *IstioDecorator) decorateServices(target *kubernetes.DeployableServices
 			Spec: v1alpha3.VirtualService{
 				Hosts: []string{publicRule.ServiceName},
 				Tcp: []*v1alpha3.TCPRoute{
-				{
-					Route: []*v1alpha3.RouteDestination{
 					{
-					Destination: &v1alpha3.Destination{
-						Host: publicRule.ServiceName,
-						Port: &v1alpha3.PortSelector{Number: uint32(publicRule.TargetPort)}},
+						Route: []*v1alpha3.RouteDestination{
+							{
+								Destination: &v1alpha3.Destination{
+									Host: publicRule.ServiceName,
+									Port: &v1alpha3.PortSelector{Number: uint32(publicRule.TargetPort)}},
+							},
+						},
+						Match: []*v1alpha3.L4MatchAttributes{
+							{
+								Port: uint32(publicRule.TargetPort),
+							},
+						},
 					},
-					},
-					Match: []*v1alpha3.L4MatchAttributes {
-					{
-						Port: uint32(publicRule.TargetPort),
-					},
-					},
-				},
 				},
 			},
 		}
@@ -242,8 +241,6 @@ func (id *IstioDecorator) decorateNamespace(namespace *kubernetes.DeployableName
 	namespace.Namespace.Labels[IstioLabelInjection] = "enabled"
 	return nil
 }
-
-
 
 func (id *IstioDecorator) generateLabels(d *kubernetes.DeployableIngress,
 	service *grpc_application_go.ServiceInstance) map[string]string {

--- a/pkg/decorators/network/zerotier/zerotier_decorator.go
+++ b/pkg/decorators/network/zerotier/zerotier_decorator.go
@@ -140,7 +140,7 @@ func (d *ZerotierDecorator) createSidecars(dep *kubernetes.DeployableDeployments
 			},
 
 			// The proxy exposes the same ports of the deployment
-			Ports: getContainerPorts(service.ExposedPorts),
+			Ports:           getContainerPorts(service.ExposedPorts),
 			ImagePullPolicy: DefaultImagePullPolicy,
 			SecurityContext: &apiv1.SecurityContext{
 				RunAsUser:  privilegedUser,
@@ -269,7 +269,7 @@ func (d *ZerotierDecorator) createInbounds(dep *kubernetes.DeployableDeployments
 									},
 								},
 								// The proxy exposes the same ports of the deployment + the ztport
-								Ports: getContainerPorts(service.ExposedPorts),
+								Ports:           getContainerPorts(service.ExposedPorts),
 								ImagePullPolicy: DefaultImagePullPolicy,
 								SecurityContext: &apiv1.SecurityContext{
 									RunAsUser:  privilegedUser,
@@ -313,14 +313,13 @@ func (d *ZerotierDecorator) createInbounds(dep *kubernetes.DeployableDeployments
 	return nil
 }
 
-
 func generateContainerLabelsInbound(d *kubernetes.DeployableDeployments,
 	service *grpc_conductor_go.ServiceInstance) map[string]string {
 
 	extendedLabels := make(map[string]string, 0)
 	if service.Labels != nil {
 		// users have already defined labels for this app
-		for k,v := range service.Labels {
+		for k, v := range service.Labels {
 			extendedLabels[k] = v
 		}
 	}
@@ -414,7 +413,7 @@ func generateContainerVars(d *kubernetes.DeployableDeployments,
 //  return:
 //   list of ports into k8s api format
 func getContainerPorts(ports []*grpc_application_go.Port) []apiv1.ContainerPort {
-	obtained := make([]apiv1.ContainerPort,0)
+	obtained := make([]apiv1.ContainerPort, 0)
 	for _, p := range ports {
 		obtained = append(obtained, apiv1.ContainerPort{ContainerPort: p.ExposedPort, Name: p.Name})
 	}

--- a/pkg/executor/decorator.go
+++ b/pkg/executor/decorator.go
@@ -18,7 +18,7 @@
 package executor
 
 import (
-    "github.com/nalej/derrors"
+	"github.com/nalej/derrors"
 )
 
 // This decorator has to be implemented by any network solution that modifies existing basic or not basic
@@ -26,12 +26,12 @@ import (
 
 type NetworkDecorator interface {
 
-    // Decoratre with networking solutions entries when they are built.
-    Build(aux Deployable, args ...interface{}) derrors.Error
+	// Decoratre with networking solutions entries when they are built.
+	Build(aux Deployable, args ...interface{}) derrors.Error
 
-    // Decorate with networking solutions a deployable entry when its deployment is called.
-    Deploy(aux Deployable, args ...interface{}) derrors.Error
+	// Decorate with networking solutions a deployable entry when its deployment is called.
+	Deploy(aux Deployable, args ...interface{}) derrors.Error
 
-    // Remove any unnecessary entries when a deployable element is removed.
-    Undeploy(aux Deployable, args ...interface{}) derrors.Error
+	// Remove any unnecessary entries when a deployable element is removed.
+	Undeploy(aux Deployable, args ...interface{}) derrors.Error
 }

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -103,11 +103,11 @@ func (h *Handler) ValidDeployFragmentRequest(request *pbDeploymentMgr.Deployment
 	}
 
 	/*
-	// TODO only check if network mode in ZT is enabled
-	if request.ZtNetworkId == "" {
-		log.Error().Msg("impossible to process request with no zt_network_id")
-		return false
-	}
+		// TODO only check if network mode in ZT is enabled
+		if request.ZtNetworkId == "" {
+			log.Error().Msg("impossible to process request with no zt_network_id")
+			return false
+		}
 	*/
 	if request.Fragment == nil || request.Fragment.FragmentId == "" {
 		log.Error().Msg("impossible to process request with no fragment_id")

--- a/pkg/handler/manager.go
+++ b/pkg/handler/manager.go
@@ -71,11 +71,11 @@ type Manager struct {
 	// Config
 	PublicCredentials grpc_application_go.ImageCredentials
 	// Network decorator
-	networkDecorator     executor.NetworkDecorator
+	networkDecorator executor.NetworkDecorator
 	// Unified Logging Slave address
 	unifiedLoggingClient grpc_unified_logging_go.SlaveClient
 	// Kubernetes Client
-	NetUpdater           network.NetworkUpdater
+	NetUpdater network.NetworkUpdater
 }
 
 func NewManager(

--- a/pkg/handler/manager.go
+++ b/pkg/handler/manager.go
@@ -17,16 +17,21 @@
 package handler
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"github.com/nalej/deployment-manager/internal/entities"
 	"github.com/nalej/deployment-manager/internal/structures"
 	"github.com/nalej/deployment-manager/internal/structures/monitor"
 	"github.com/nalej/deployment-manager/pkg/executor"
+	"github.com/nalej/deployment-manager/pkg/network"
 	"github.com/nalej/grpc-application-go"
 	pbConductor "github.com/nalej/grpc-conductor-go"
 	pbDeploymentMgr "github.com/nalej/grpc-deployment-manager-go"
+	"github.com/nalej/grpc-unified-logging-go"
+	"github.com/nalej/grpc-utils/pkg/conversions"
 	"github.com/rs/zerolog/log"
+	"k8s.io/client-go/kubernetes"
 	"time"
 )
 
@@ -46,6 +51,9 @@ const (
 	StageCheckTimeout = 480
 	// Time to wait between checks in the queue in milliseconds.
 	CheckQueueSleepTime = 2000
+	DefaultTimeout      = time.Minute
+	CheckSleepTime      = time.Second * 4
+	ExpireTimeout       = time.Minute * 3
 )
 
 type Manager struct {
@@ -63,7 +71,11 @@ type Manager struct {
 	// Config
 	PublicCredentials grpc_application_go.ImageCredentials
 	// Network decorator
-	networkDecorator executor.NetworkDecorator
+	networkDecorator     executor.NetworkDecorator
+	// Unified Logging Slave address
+	unifiedLoggingClient grpc_unified_logging_go.SlaveClient
+	// Kubernetes Client
+	NetUpdater           network.NetworkUpdater
 }
 
 func NewManager(
@@ -72,7 +84,10 @@ func NewManager(
 	queue structures.RequestsQueue,
 	dnsHosts []string, monitored monitor.MonitoredInstances,
 	publicCredentials grpc_application_go.ImageCredentials,
-	networkDecorator executor.NetworkDecorator) *Manager {
+	networkDecorator executor.NetworkDecorator,
+	ulClient grpc_unified_logging_go.SlaveClient,
+	K8sClient *kubernetes.Clientset) *Manager {
+	netUpdater := network.NewKubernetesNetworkUpdater(K8sClient)
 	return &Manager{
 		executor:              *executor,
 		clusterPublicHostname: clusterPublicHostname,
@@ -81,6 +96,8 @@ func NewManager(
 		queue:                 queue,
 		PublicCredentials:     publicCredentials,
 		networkDecorator:      networkDecorator,
+		unifiedLoggingClient:  ulClient,
+		NetUpdater:            netUpdater,
 	}
 }
 
@@ -216,6 +233,51 @@ func (m *Manager) Execute(request *pbDeploymentMgr.DeploymentFragmentRequest) er
 	return nil
 }
 
+// expireLogs send a message to unified-logging to expire the logs of an application
+func (m *Manager) expireLogs(organizationId string, appInstanceId string) {
+
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultTimeout)
+	defer cancel()
+
+	_, ulErr := m.unifiedLoggingClient.Expire(ctx, &grpc_unified_logging_go.ExpirationRequest{
+		OrganizationId: organizationId,
+		AppInstanceId:  appInstanceId,
+	})
+	if ulErr != nil {
+		log.Warn().Str("error", conversions.ToDerror(ulErr).DebugReport()).Msg("error expiring logs")
+	}
+	log.Debug().Str("organizationID", organizationId).Str("instanceID", appInstanceId).Msg("logs expired")
+}
+
+// checkNamespaceToExpireLogs runs a loop to check when the application namespace is terminated
+func (m *Manager) checkNamespaceToExpireLogs(request *pbDeploymentMgr.UndeployRequest) {
+
+	sleep := time.NewTicker(CheckSleepTime)
+
+	ctxExpire, cancelExpire := context.WithTimeout(context.Background(), ExpireTimeout)
+	defer cancelExpire()
+
+	for {
+		select {
+		case <-sleep.C:
+			exists, err := m.NetUpdater.CheckIfNamespaceExists(request.OrganizationId, request.AppInstanceId)
+			if err != nil {
+				log.Warn().Str("organizationID", request.OrganizationId).Str("instanceID", request.AppInstanceId).
+					Str("error", err.DebugReport()).Msg("Unable to expire logs")
+			}
+			if !exists {
+				m.expireLogs(request.OrganizationId, request.AppInstanceId)
+				sleep.Stop()
+				return
+			}
+		case <-ctxExpire.Done():
+			log.Warn().Str("organizationID", request.OrganizationId).Str("instanceID", request.AppInstanceId).Msg("Unable to expire logs, context deadline")
+			return
+		}
+	}
+
+}
+
 func (m *Manager) Undeploy(request *pbDeploymentMgr.UndeployRequest) error {
 	log.Debug().Str("appInstanceID", request.AppInstanceId).Msg("undeploy app instance with id")
 
@@ -223,6 +285,8 @@ func (m *Manager) Undeploy(request *pbDeploymentMgr.UndeployRequest) error {
 	err := m.executor.UndeployNamespace(request, m.networkDecorator)
 	// set the requested application as terminating
 	m.monitored.SetAppStatus(request.AppInstanceId, entities.FRAGMENT_TERMINATING, nil)
+
+	go m.checkNamespaceToExpireLogs(request)
 
 	if err != nil {
 		log.Error().Err(err).Msgf("impossible to undeploy app %s", request.AppInstanceId)

--- a/pkg/kubernetes/kubernetes_deployment.go
+++ b/pkg/kubernetes/kubernetes_deployment.go
@@ -62,9 +62,9 @@ type DeployableDeployments struct {
 func NewDeployableDeployment(
 	client *kubernetes.Clientset, data entities.DeploymentMetadata, networkDecorator executor.NetworkDecorator) *DeployableDeployments {
 	return &DeployableDeployments{
-		Client:      client.AppsV1().Deployments(data.Namespace),
-		Data:        data,
-		Deployments: make([]*appsv1.Deployment, 0),
+		Client:           client.AppsV1().Deployments(data.Namespace),
+		Data:             data,
+		Deployments:      make([]*appsv1.Deployment, 0),
 		networkDecorator: networkDecorator,
 	}
 }
@@ -172,7 +172,6 @@ func (d *DeployableDeployments) Build() error {
 			extendedLabels = make(map[string]string, 0)
 		}
 
-
 		extendedLabels[utils.NALEJ_ANNOTATION_DEPLOYMENT_FRAGMENT] = d.Data.FragmentId
 		extendedLabels[utils.NALEJ_ANNOTATION_ORGANIZATION_ID] = d.Data.OrganizationId
 		extendedLabels[utils.NALEJ_ANNOTATION_ORGANIZATION_NAME] = common.FormatNameWithHyphen(d.Data.OrganizationName)
@@ -196,7 +195,7 @@ func (d *DeployableDeployments) Build() error {
 		selectorLabels := map[string]string{
 			utils.NALEJ_ANNOTATION_APP_INSTANCE_ID: d.Data.AppInstanceId,
 			utils.NALEJ_ANNOTATION_ORGANIZATION_ID: service.OrganizationId,
-			utils.NALEJ_ANNOTATION_SERVICE_NAME: common.FormatName(service.ServiceName),
+			utils.NALEJ_ANNOTATION_SERVICE_NAME:    common.FormatName(service.ServiceName),
 		}
 
 		deployment := appsv1.Deployment{
@@ -312,7 +311,6 @@ func (d *DeployableDeployments) Build() error {
 	return nil
 }
 
-
 func (d *DeployableDeployments) Deploy(controller executor.DeploymentController) error {
 
 	// same approach for service Deployments
@@ -416,4 +414,3 @@ func (d *DeployableDeployments) getContainerPorts(ports []*pbApplication.Port) [
 	}
 	return obtained
 }
-

--- a/pkg/kubernetes/kubernetes_ingress.go
+++ b/pkg/kubernetes/kubernetes_ingress.go
@@ -148,11 +148,11 @@ func (di *DeployableIngress) BuildIngressesForServiceWithRule(service *grpc_cond
 
 	// create the ingress annotations
 	annotations := map[string]string{
-		"kubernetes.io/ingress.class": "nginx",
+		"kubernetes.io/ingress.class":                  "nginx",
 		"nginx.ingress.kubernetes.io/service-upstream": "true",
-		"organizationId":              service.OrganizationId,
-		"appInstanceId":               di.Data.AppInstanceId,
-		"serviceId":                   service.ServiceId,
+		"organizationId":                               service.OrganizationId,
+		"appInstanceId":                                di.Data.AppInstanceId,
+		"serviceId":                                    service.ServiceId,
 	}
 	// Overwrite the application root path with the user specified one so that when
 	// the user accesses the endpoint through the DNS it is automatically redirected

--- a/pkg/kubernetes/kubernetes_namespace.go
+++ b/pkg/kubernetes/kubernetes_namespace.go
@@ -51,9 +51,9 @@ type DeployableNamespace struct {
 func NewDeployableNamespace(client *kubernetes.Clientset, data entities.DeploymentMetadata,
 	networkDecorator executor.NetworkDecorator) *DeployableNamespace {
 	return &DeployableNamespace{
-		client:    client.CoreV1().Namespaces(),
-		data:      data,
-		Namespace: apiv1.Namespace{},
+		client:           client.CoreV1().Namespaces(),
+		data:             data,
+		Namespace:        apiv1.Namespace{},
 		networkDecorator: networkDecorator,
 	}
 }
@@ -123,7 +123,7 @@ func (n *DeployableNamespace) Undeploy() error {
 		utils.NALEJ_ANNOTATION_APP_INSTANCE_ID, n.data.AppInstanceId,
 	)
 	options := metav1.ListOptions{
-		LabelSelector:        queryString,
+		LabelSelector: queryString,
 	}
 
 	list, err := n.client.List(options)

--- a/pkg/kubernetes/kubernetes_service.go
+++ b/pkg/kubernetes/kubernetes_service.go
@@ -54,9 +54,9 @@ func NewDeployableService(client *kubernetes.Clientset, data entities.Deployment
 	decorator executor.NetworkDecorator) *DeployableServices {
 
 	return &DeployableServices{
-		Client:   client.CoreV1().Services(data.Namespace),
-		Data:     data,
-		Services: make([]ServiceInfo, 0),
+		Client:           client.CoreV1().Services(data.Namespace),
+		Data:             data,
+		Services:         make([]ServiceInfo, 0),
 		networkDecorator: decorator,
 	}
 }
@@ -69,14 +69,13 @@ func (s *DeployableServices) Build() error {
 	for serviceIndex, service := range s.Data.Stage.Services {
 
 		// Check if the service already exists
-		_, err := s.Client.Get(common.FormatName(service.ServiceName),metav1.GetOptions{})
-		if !errors.IsNotFound(err)  {
-			log.Debug().Str("serviceName",service.ServiceName).Msg("the service already exists, no need to be be created")
+		_, err := s.Client.Get(common.FormatName(service.ServiceName), metav1.GetOptions{})
+		if !errors.IsNotFound(err) {
+			log.Debug().Str("serviceName", service.ServiceName).Msg("the service already exists, no need to be be created")
 			continue
 		}
 
 		log.Debug().Msgf("build service %s %d out of %d", service.ServiceId, serviceIndex+1, len(s.Data.Stage.Services))
-
 
 		extendedLabels := make(map[string]string, 0)
 		extendedLabels[utils.NALEJ_ANNOTATION_ORGANIZATION_ID] = s.Data.OrganizationId
@@ -89,7 +88,7 @@ func (s *DeployableServices) Build() error {
 		selectorLabels := map[string]string{
 			utils.NALEJ_ANNOTATION_APP_INSTANCE_ID: s.Data.AppInstanceId,
 			utils.NALEJ_ANNOTATION_ORGANIZATION_ID: service.OrganizationId,
-			utils.NALEJ_ANNOTATION_SERVICE_NAME: common.FormatName(service.ServiceName),
+			utils.NALEJ_ANNOTATION_SERVICE_NAME:    common.FormatName(service.ServiceName),
 		}
 
 		ports := getServicePorts(service.ExposedPorts)
@@ -104,8 +103,8 @@ func (s *DeployableServices) Build() error {
 					ExternalName: common.FormatName(service.ServiceName),
 					Ports:        ports,
 					//Type:         apiv1.ServiceTypeNodePort,
-					Type:         apiv1.ServiceTypeClusterIP,
-					Selector:     selectorLabels,
+					Type:     apiv1.ServiceTypeClusterIP,
+					Selector: selectorLabels,
 				},
 			}
 			log.Debug().Str("serviceId", service.ServiceId).Str("serviceInstanceId", service.ServiceInstanceId).
@@ -133,7 +132,7 @@ func (s *DeployableServices) Deploy(controller executor.DeploymentController) er
 	for _, servInfo := range s.Services {
 
 		// if the service is already there skip
-		_, err := s.Client.Get(servInfo.Service.Name,metav1.GetOptions{})
+		_, err := s.Client.Get(servInfo.Service.Name, metav1.GetOptions{})
 		if !errors.IsNotFound(err) {
 			log.Debug().Str("serviceName", servInfo.Service.Name).Msg("service already deployed. Skip it")
 			continue
@@ -144,7 +143,7 @@ func (s *DeployableServices) Deploy(controller executor.DeploymentController) er
 			log.Error().Err(err).Msgf("error creating service %s", servInfo.Service.Name)
 			return err
 		}
-		log.Debug().Str("serviceName",servInfo.Service.Name).Str("uid", string(created.GetUID())).
+		log.Debug().Str("serviceName", servInfo.Service.Name).Str("uid", string(created.GetUID())).
 			Str("appInstanceID", s.Data.AppInstanceId).
 			Str("serviceID", servInfo.ServiceId).Msg("add service resource to be monitored")
 
@@ -163,7 +162,6 @@ func (s *DeployableServices) Deploy(controller executor.DeploymentController) er
 	}
 	return nil
 }
-
 
 func (s *DeployableServices) Undeploy() error {
 	for _, servInfo := range s.Services {

--- a/pkg/network/updater.go
+++ b/pkg/network/updater.go
@@ -108,7 +108,6 @@ func (knu *KubernetesNetworkUpdater) CheckIfNamespaceExists(organizationID strin
 	return true, nil
 }
 
-
 // GetTargetNamespace obtains the namespace where the application runs.
 // params:
 //  organizationID
@@ -415,7 +414,7 @@ func (knu *KubernetesNetworkUpdater) SendLeaveZTConnection(targetPods []TargetPo
 
 func (knu *KubernetesNetworkUpdater) getSidecarClient(targetIP string) (grpc_zt_nalej_go.SidecarClient, context.Context, context.CancelFunc, derrors.Error) {
 	address := fmt.Sprintf("%s:%d", targetIP, ZtRedirectorPort)
-	log.Debug().Msgf("get sidecar client for %s",address)
+	log.Debug().Msgf("get sidecar client for %s", address)
 	conn, err := grpc.Dial(address, grpc.WithInsecure())
 	if err != nil {
 		return nil, nil, nil, derrors.AsError(err, "cannot create connection with unified logging coordinator")

--- a/pkg/service/deployment_manager_service.go
+++ b/pkg/service/deployment_manager_service.go
@@ -386,7 +386,6 @@ func (d *DeploymentManagerService) startMetrics(httpListener net.Listener, errCh
 	return httpServer, nil
 }
 
-
 func getNetworkDecorator(configuration *config.Config) (executor.NetworkDecorator, derrors.Error) {
 	switch configuration.NetworkType {
 	case config.NetworkTypeZt:

--- a/pkg/service/deployment_manager_service.go
+++ b/pkg/service/deployment_manager_service.go
@@ -24,7 +24,8 @@ import (
 	"github.com/nalej/deployment-manager/pkg/decorators/network/istio"
 	"github.com/nalej/deployment-manager/pkg/decorators/network/zerotier"
 	"github.com/nalej/deployment-manager/pkg/executor"
-	offline_policy "github.com/nalej/deployment-manager/pkg/offline-policy"
+	"github.com/nalej/deployment-manager/pkg/offline-policy"
+	"github.com/nalej/grpc-unified-logging-go"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -239,16 +240,24 @@ func NewDeploymentManagerService(cfg *config.Config) (*DeploymentManagerService,
 
 	// Instantiate deployment manager service
 	log.Info().Msg("star deployment requests manager")
-	mgr := handler.NewManager(&exec, cfg.ClusterPublicHostname, requestsQueue, nalejDNSForPods, instanceMonitor,
-		cfg.PublicCredentials, networkDecorator)
-	go mgr.Run()
-	log.Info().Msg("done")
+
+	ulConn, ulErr := grpc.Dial(cfg.UnifiedLoggingAddress, grpc.WithInsecure())
+	if ulErr != nil {
+		return nil, derrors.AsError(ulErr, "cannot create connection with unified slave coordinator")
+	}
+	ulClient := grpc_unified_logging_go.NewSlaveClient(ulConn)
 
 	// Instantiate network manager service
 	k8sClient, err := kubernetes.GetKubernetesClient(cfg.Local)
 	if err != nil {
 		return nil, err
 	}
+
+	mgr := handler.NewManager(&exec, cfg.ClusterPublicHostname, requestsQueue, nalejDNSForPods, instanceMonitor,
+		cfg.PublicCredentials, networkDecorator, ulClient, k8sClient)
+	go mgr.Run()
+	log.Info().Msg("done")
+
 	net := network.NewManager(clusterAPIConn, clusterAPILoginHelper, k8sClient)
 
 	// Instantiate app network manager service


### PR DESCRIPTION
### What does this PR do?
when undeploying an application, a loop is running to check when the namespace is finished and call to unified-logging to expire logs
#### Where should the reviewer start?

#### What is missing?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant tickets?

- [NP-2463](https://nalej.atlassian.net/browse/NP-2463)

#### Screenshots (if appropriate)

#### Questions
